### PR TITLE
bbb-webrtc-sfu: add missing sources/default.nix

### DIFF
--- a/packages/sources/bbb-webrtc-sfu/default.nix
+++ b/packages/sources/bbb-webrtc-sfu/default.nix
@@ -1,0 +1,16 @@
+{ stdenvNoCC, callPackage }:
+
+stdenvNoCC.mkDerivation {
+  pname = "bbb-webrtc-sfu";
+  version = builtins.readFile ./version;
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  src = callPackage ./raw-source.nix {};
+
+  installPhase = ''
+    cp -r $PWD $out
+  '';
+}


### PR DESCRIPTION
```
-> Checking out sources
error: --- SysError ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- nix-build
opening file '/home/andy/projects/bbb4nix/packages/sources/bbb-webrtc-sfu/default.nix': No such file or directory
cp: cannot stat '': No such file or directory
```