### PR TITLE
packages/generate.sh: fix tag detection by moving cut

### DIFF
--- a/packages/sources/generate.sh
+++ b/packages/sources/generate.sh
@@ -55,9 +55,10 @@ updateByTag() {
 		| grep -v svn \
 		| grep -v '{}' \
 		| awk '{print $2}' \
+		| cut -d'/' -f3 \
 		| sort -n \
 		| tail -n1 \
-		| cut -d'/' -f3 | tr -d '\n' > "${dir}/version"
+		| tr -d '\n' > "${dir}/version"
 	if oneIsChanged "${dir}"/*; then
 		prepareRawSource "${dir}" "${owner}" "${repo}"
 	fi
@@ -74,9 +75,10 @@ updateByTagWithoutV() {
 		| grep -v '{}' \
 		| grep 'tags/[0-9]' \
 		| awk '{print $2}' \
+		| cut -d'/' -f3 \
 		| sort -n \
 		| tail -n1 \
-		| cut -d'/' -f3 | tr -d '\n' > "${dir}/version"
+		| tr -d '\n' > "${dir}/version"
 	if oneIsChanged "${dir}"/*; then
 		prepareRawSource "${dir}" "${owner}" "${repo}"
 	fi


### PR DESCRIPTION
otherwise sort -n doesn't work correctly and kurento-module-creator ends up as 6.9.0 instead of 6.14.0