### PR TITLE
packages/kurento-module-creator: fix for newer mvn2nix

### DIFF
--- a/packages/kurento-module-creator/default.nix
+++ b/packages/kurento-module-creator/default.nix
@@ -1,6 +1,6 @@
 { stdenvNoCC, callPackage, cmake, jdk, maven, makeWrapper }: let
   mvn2nix = import (callPackage ../sources/mvn2nix {}) {};
-  mavenRepository = mvn2nix.buildMavenRepository { dependencies = import ./dependencies.nix; };
+  mavenRepository = mvn2nix.buildMavenRepositoryFromLockFile { file = ./dependencies.nix; };
 
   src = callPackage ../sources/kurento-module-creator {};
 

--- a/packages/kurento-module-creator/generate.sh
+++ b/packages/kurento-module-creator/generate.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 cd "$(dirname "${0}")"
 . ../utils.sh
 
-PATH="$(nix-build --no-out-link ../checkouts/mvn2nix)/bin:${PATH}"
+rm -rf ~/.m2
+PATH="$(nix-build --no-out-link ../checkouts/mvn2nix -A mvn2nix)/bin:${PATH}"
 export PATH
 
 # Generate lock


### PR DESCRIPTION
still seems to only work when .git exists…