### PR TITLE
modules/simple: bbb-html5 is at /html5client not /client

### DIFF
--- a/modules/simple.nix
+++ b/modules/simple.nix
@@ -27,7 +27,15 @@ in {
       };
       web = {
         enable = true;
-        config."bigbluebutton.web.serverURL" = "https://${cfg.domain}";
+        config = let
+          clientLocation = ''''${bigbluebutton.web.serverURL}/html5client'';
+        in {
+          "bigbluebutton.web.serverURL" = "https://${cfg.domain}";
+          "defaultClientUrl" = "${clientLocation}/BigBlueButton.html";
+          "defaultGuestWaitURL" = "${clientLocation}/guest-wait.html";
+          "defaultAvatarURL" = "${clientLocation}/avatar.png";
+          "defaultConfigURL" = "${clientLocation}/conf/config.xml";
+        };
         stunServers = [ "stun:${cfg.domain}" ];
         turnServers = [
           { url = "turn:${cfg.domain}?transport=tcp"; }


### PR DESCRIPTION
Alternative solutions would be redirecting in nginx or also proxying to bbb-html5 at `/client`.