### PR TITLE
[20.09] modules/redis: don't decrease net.core.somaxconn

### DIFF
--- a/modules/redis.nix
+++ b/modules/redis.nix
@@ -60,10 +60,6 @@ in {
       vmOverCommit = true;
     };
 
-    boot.kernel.sysctl = {
-      "net.core.somaxconn" = "512";
-    };
-
     systemd.services.redis-bigbluebutton.serviceConfig = {
       PrivateNetwork = false;
     };


### PR DESCRIPTION
(cherry picked from commit 62a4e816948d96e20214258ef0448ce5aaced8ef)